### PR TITLE
Исправление выбранного вида классификатора с "ru" на "spellcheck"

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <div data-author="fukkatsumichanpewpew">
        <h4 class="author">fukkatsumichanpewpew:</h4>
        <ul class="changelog">
-        <li class="ru">Исправление пунктуации и корректировка СМЭХа на СПИН в соответствии с Wikipedia.</li>
+        <li class="spellcheck">Исправление пунктуации и корректировка СМЭХа на СПИН в соответствии с Wikipedia.</li>
        </ul>
       </div>
      </div>


### PR DESCRIPTION
Исправление выбранного вида классификатора с "ru" на "spellcheck".

<img width="334" height="40" alt="image" src="https://github.com/user-attachments/assets/9df861a0-0fb1-401c-865c-6693a6109d30" />

<img width="1156" height="60" alt="image" src="https://github.com/user-attachments/assets/09c1a0b3-81fc-4c9c-8216-fc917625b8d9" />

> <img width="974" height="444" alt="image" src="https://github.com/user-attachments/assets/dfa9cec2-3b88-44e3-9110-cc70633e4481" />

